### PR TITLE
chore: enable `no-unnecessary-condition` rule as warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,7 @@ module.exports = {
 		"@typescript-eslint/no-floating-promises": "warn",
 		"@typescript-eslint/no-misused-promises": "warn",
 		"@typescript-eslint/no-non-null-assertion": "warn",
+		"@typescript-eslint/no-unnecessary-condition": "warn",
 		"@typescript-eslint/no-unsafe-assignment": "warn",
 		"@typescript-eslint/no-unsafe-call": "warn",
 		"@typescript-eslint/no-unsafe-member-access": "warn",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
 		"@typescript-eslint/no-floating-promises": "warn",
 		"@typescript-eslint/no-misused-promises": "warn",
 		"@typescript-eslint/no-non-null-assertion": "warn",
-		"@typescript-eslint/no-unnecessary-condition": "warn",
+		"@typescript-eslint/no-unnecessary-condition": "warn", // @TODO: set to error and resolve issues
 		"@typescript-eslint/no-unsafe-assignment": "warn",
 		"@typescript-eslint/no-unsafe-call": "warn",
 		"@typescript-eslint/no-unsafe-member-access": "warn",


### PR DESCRIPTION
## Summary

Setting this rule as a warning can help identify unnecessary usages of optional chaining operator, and could additionally bring up potential typings issues.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
